### PR TITLE
Set noConnectionReuse in all tests

### DIFF
--- a/tests/scripts/constant-vus.js
+++ b/tests/scripts/constant-vus.js
@@ -23,7 +23,7 @@ export let options = {
     http_req_failed: ['rate<0.1'],
   },
   setupTimeout: '300s',
-  noConnectionReuse: false,
+  noConnectionReuse: true,
   discardResponseBodies: true,
   // executor: 'constant-vus', // this is the default executor and implied
   vus: 20,

--- a/tests/scripts/ramping-vus.js
+++ b/tests/scripts/ramping-vus.js
@@ -22,7 +22,7 @@ export let options = {
     http_req_failed: ['rate<0.1'],
   },
   setupTimeout: '300s',
-  noConnectionReuse: false,
+  noConnectionReuse: true,
   discardResponseBodies: true,
   scenarios: {
     ramp: {


### PR DESCRIPTION
Ensures the same app backing a service isn't receiving all requests