### PR TITLE
feat(apps): add cpu-intensive app

### DIFF
--- a/apps/cpu-intensive/.gitignore
+++ b/apps/cpu-intensive/.gitignore
@@ -1,0 +1,2 @@
+main.wasm
+.spin/

--- a/apps/cpu-intensive/go.mod
+++ b/apps/cpu-intensive/go.mod
@@ -1,0 +1,7 @@
+module github.com/cpu_intensive
+
+go 1.20
+
+require github.com/fermyon/spin/sdk/go/v2 v2.0.0-20240116170232-bbbb59b821da
+
+require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/apps/cpu-intensive/go.sum
+++ b/apps/cpu-intensive/go.sum
@@ -1,0 +1,4 @@
+github.com/fermyon/spin/sdk/go/v2 v2.0.0-20240116170232-bbbb59b821da h1:+VKaIRRCsRuKggpt7xDF5Euc0eSShnwLVFNC2evv2Qo=
+github.com/fermyon/spin/sdk/go/v2 v2.0.0-20240116170232-bbbb59b821da/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/apps/cpu-intensive/main.go
+++ b/apps/cpu-intensive/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+)
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		// Default number to calculate
+		x := 42
+
+		// Use number if provided via the request path eg '/42'
+		if pathInfos := strings.Split(r.Header.Get("spin-path-info"), "/"); len(pathInfos) == 2 {
+			if number, err := strconv.Atoi(pathInfos[1]); err == nil {
+				x = number
+			}
+		}
+
+		fmt.Printf("Calculating fib(%d)\n", x)
+		fmt.Fprintf(w, "fib(%d) = %d\n", x, fib(x))
+	})
+}
+
+func fib(n int) int {
+	if n < 2 {
+		return n
+	}
+	return fib(n-2) + fib(n-1)
+}
+
+func main() {}

--- a/apps/cpu-intensive/spin.toml
+++ b/apps/cpu-intensive/spin.toml
@@ -1,0 +1,21 @@
+spin_manifest_version = 2
+
+[application]
+name = "cpu-intensive"
+version = "0.1.0"
+authors = [
+  "Caleb Schoepp <caleb.schoepp@fermyon.com>",
+  "Vaughn Dice <vaughn.dice@fermyon.com>"
+]
+description = "A CPU-intensive Spin app that computes Fibonacci sequences"
+
+[[trigger.http]]
+route = "/..."
+component = "fibonacci"
+
+[component.fibonacci]
+source = "main.wasm"
+allowed_outbound_hosts = []
+[component.fibonacci.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+watch = ["**/*.go", "go.mod"]


### PR DESCRIPTION
- adds a cpu-intensive app adapted from https://github.com/spinkube/spin-operator/tree/main/apps/cpu-load-gen

TODO (?)
- [ ] Do we want to add a test case specific to this app?  Or were we thinking of a test case down the line that would use this (perhaps with the [memory-intensive app](https://github.com/fermyon/spinkube-performance/issues/65), etc.?)

Closes https://github.com/fermyon/spinkube-performance/issues/64