### PR TITLE
feat(apps): add memory-intensive app

### DIFF
--- a/apps/mem-intensive/.gitignore
+++ b/apps/mem-intensive/.gitignore
@@ -1,0 +1,2 @@
+main.wasm
+.spin/

--- a/apps/mem-intensive/go.mod
+++ b/apps/mem-intensive/go.mod
@@ -1,0 +1,7 @@
+module github.com/mem_intensive
+
+go 1.20
+
+require github.com/fermyon/spin/sdk/go/v2 v2.0.0-20240116170232-bbbb59b821da
+
+require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/apps/mem-intensive/go.sum
+++ b/apps/mem-intensive/go.sum
@@ -1,0 +1,4 @@
+github.com/fermyon/spin/sdk/go/v2 v2.0.0-20240116170232-bbbb59b821da h1:+VKaIRRCsRuKggpt7xDF5Euc0eSShnwLVFNC2evv2Qo=
+github.com/fermyon/spin/sdk/go/v2 v2.0.0-20240116170232-bbbb59b821da/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/apps/mem-intensive/main.go
+++ b/apps/mem-intensive/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+)
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		// The baconipsum api maxes out at 100 paras, so potentially make repeated requests
+		para_max := 100
+		// Default number of paragraphs to fetch
+		paras := 1000
+
+		// Use number if provided via the request path eg '/42'
+		if pathInfos := strings.Split(r.Header.Get("spin-path-info"), "/"); len(pathInfos) == 2 {
+			if number, err := strconv.Atoi(pathInfos[1]); err == nil {
+				paras = number
+			}
+		}
+
+		url := fmt.Sprintf("https://baconipsum.com/api/?type=all-meat&paras=%d&start-with-lorem=1&format=text", paras)
+		repeats := 1
+		if paras > para_max {
+			repeats = int(math.Ceil(float64(paras / para_max)))
+			url = fmt.Sprintf("https://baconipsum.com/api/?type=all-meat&paras=%d&start-with-lorem=1&format=text", para_max)
+		}
+
+		fmt.Printf("Calculating the number of instances of the word 'bacon' within %d paragraphs of baconipsum...\n", paras)
+
+		text := ""
+		for i := 0; i < repeats; i++ {
+			resp, err := spinhttp.Get(url)
+			if err != nil {
+				fmt.Printf("Error encountered attempting to make a GET request to url '%s': %s\n", url, err)
+				os.Exit(1)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			defer resp.Body.Close()
+			if err != nil {
+				fmt.Println("Error encountered attempting to read response body: ", err)
+				os.Exit(1)
+			}
+			text += string(body)
+		}
+
+		fmt.Fprintf(w, "paragraph count = %d\nbacon count = %d\n", paras, bacon_count(text))
+	})
+}
+
+func bacon_count(text string) int {
+	count := 0
+	words := strings.Fields(text)
+
+	for _, word := range words {
+		if word == "bacon" {
+			count++
+		}
+	}
+
+	return count
+}
+
+func main() {}

--- a/apps/mem-intensive/spin.toml
+++ b/apps/mem-intensive/spin.toml
@@ -1,0 +1,18 @@
+spin_manifest_version = 2
+
+[application]
+name = "mem-intensive"
+version = "0.1.0"
+authors = [ "Vaughn Dice <vaughn.dice@fermyon.com>" ]
+description = "A memory-intensive Spin app that counts the number of 'bacon's from N number of baconipsum paragraphs"
+
+[[trigger.http]]
+route = "/..."
+component = "bacon-counter"
+
+[component.bacon-counter]
+source = "main.wasm"
+allowed_outbound_hosts = ["https://baconipsum.com"]
+[component.bacon-counter.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+watch = ["**/*.go", "go.mod"]


### PR DESCRIPTION
- Add a memory-intensive app based on thought mentioned in https://github.com/fermyon/spinkube-performance/issues/65#issuecomment-2155262621

Happy to scrap this for something more ideal, but thought I'd put this up just in case it suited our needs.

In test(s), we can increase the memory use via upping the requested # of paragraphs of baconipsum to be fetched, eg `curl localhost:3000/10000`

Closes https://github.com/fermyon/spinkube-performance/issues/65