### PR TITLE
fix/chore(*): metadata label key updates, inject_env fix

### DIFF
--- a/environment/kind-config.yml
+++ b/environment/kind-config.yml
@@ -5,6 +5,8 @@ nodes:
 - role: worker
   labels:
     workload: system
+    node.kubernetes.io/instance-type: kind
 - role: worker
   labels:
     runtime: containerd-shim-spin
+    node.kubernetes.io/instance-type: kind

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -34,7 +34,7 @@ wait_for_testrun() {
 inject_envs_with_prefix() {
     local prefix=$1
     local file=$2
-    env | grep "^$prefix" | while IFS= read -r line; do
+    env | { grep "^$prefix" || true; } | while IFS= read -r line; do
         IFS="=" read -r name value <<< "$line"
         export name
         export value

--- a/utils.sh
+++ b/utils.sh
@@ -44,9 +44,9 @@ export_node_info() {
   # Get architecture and OS of node provisioned by runtime installer (and labeled with 'runtime=containerd-shim-spin')
   node_info=$(kubectl get nodes -l runtime=$executor -o json | \
     jq -Cjr '.items[] | .metadata.name,"
-      ",.metadata.labels."beta.kubernetes.io/os","
-      ",.metadata.labels."beta.kubernetes.io/arch","
-      ",.metadata.labels."beta.kubernetes.io/instance-type","
+      ",.metadata.labels."kubernetes.io/os","
+      ",.metadata.labels."kubernetes.io/arch","
+      ",.metadata.labels."node.kubernetes.io/instance-type","
       ",.metadata.annotations."shim_version", "\n"' | head)
   cluster_name=$(kubectl config current-context)
   node_name="$(echo $node_info | cut -d' ' -f1)"


### PR DESCRIPTION
- Update `inject_envs_with_prefix` to exit gracefully if no env vars are found (`grep` by default exits non-zero if it doesn't find a match)
  - I hit this when running with `OUTPUT=none`... previously the function would exit non-zero trying to find `K6_` prefixed env vars when there were none
- Update the metadata label keys used by `export_node_info` (remove deprecations per https://kubernetes.io/docs/reference/labels-annotations-taints/)
- Update kind-config to add the instance-type label, or else it returns a weird null string (`--tag node_instance_type=^[[0;90mnull^[[0m`) which in turn prevents the test run from ever proceeding past the initializing stage