### PR TITLE
chore(aks): switch to kubenet for network_profile

### DIFF
--- a/terraform/azure/aks/main.tf
+++ b/terraform/azure/aks/main.tf
@@ -34,8 +34,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   dns_prefix = local.base_name
   network_profile {
-    network_plugin    = "azure"
-    network_policy    = "azure"
+    network_plugin    = "kubenet"
     load_balancer_sku = "standard"
   }
 


### PR DESCRIPTION
Improved performance comes with changing from Azure CNI to the default kubenet networking profile.  Initial test run achieved ~3k rps vs ~1.8k rps with Azure CNI.

(Background on differences: https://learn.microsoft.com/en-us/azure/aks/configure-kubenet#choose-a-network-model-to-use)