### PR TITLE
chore(.github): bump spin to 2.6.0 and shim to 0.15.1

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -15,11 +15,11 @@ on:
       containerd_shim_spin_version:
         type: string
         description: 'Version of containerd-shim-spin to install'
-        default: 'v0.15.0'
+        default: 'v0.15.1'
 
 env:
   REGISTRY_URL: spinkubeperf.azurecr.io
-  SPIN_V_VERSION: "2.5.0"
+  SPIN_V_VERSION: "2.6.0"
   # Terraform env vars associated with configuration variables
   TF_VAR_prefix: ci-spinkube-perf
   TF_VAR_apps_nodepool_sku: ${{ github.event.inputs.apps_nodepool_sku }}

--- a/.github/workflows/build-and-push-spinapps.yaml
+++ b/.github/workflows/build-and-push-spinapps.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
     REGISTRY_URL: spinkubeperf.azurecr.io
-    SPIN_V_VERSION: "2.5.0"
+    SPIN_V_VERSION: "2.6.0"
     
 jobs:
   apps:


### PR DESCRIPTION
Missed these values in previous bump PRs...