### PR TITLE
fix: update resource intensive test invocation and tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ run-resource-intensive-test:
 		SK_REPLICAS=1 \
 		SK_HASH_MEMORY=10000 \
 		SK_HASH_CPU=50 \
-		SK_HASH_SLEEP=1000 \
+		SK_HASH_SLEEP_MS=1000 \
 		./tests/run.sh $(REGISTRY_URL)"
 
 run-ramping-vus-test-%:

--- a/tests/scripts/resource-intensive.js
+++ b/tests/scripts/resource-intensive.js
@@ -68,14 +68,14 @@ export function setup() {
 export default function () {
   let endpoint = deploy.serviceEndpointForApp(name, namespace, route);
 
-  let res = http.get(`${endpoint}?mem=${memoryKib}`, { tags: {memoryKib: memoryKib} });
-  check(res, { "response code was 200": (res) => res.status == 200 }, { memoryKib: memoryKib });
+  let res = http.get(`${endpoint}?mem=${memoryKib}`, { tags: {memory_kib: memoryKib} });
+  check(res, { "response code was 200": (res) => res.status == 200 }, { memory_kib: memoryKib });
   sleep(delay);
-  res = http.get(`${endpoint}?cpuIter=${cpuIter}`, { tags: {cpuIter: cpuIter} });
-  check(res, { "response code was 200": (res) => res.status == 200 }, { cpuIter: cpuIter });
+  res = http.get(`${endpoint}?cpuIter=${cpuIter}`, { tags: {cpu_iter: cpuIter} });
+  check(res, { "response code was 200": (res) => res.status == 200 }, { cpu_iter: cpuIter });
   sleep(delay);
   res = http.get(`${endpoint}?sleep=${sleepMs}`, { tags: {sleep: sleepMs} });
-  check(res, { "response code was 200": (res) => res.status == 200 }, { sleepMs: sleepMs });
+  check(res, { "response code was 200": (res) => res.status == 200 }, { sleep_ms: sleepMs });
   sleep(delay);
 }
 


### PR DESCRIPTION
The memory tag wasn't being properly propagated. Also updates tag names to follow K6 snake case conventions. 