### PR TITLE
Install Terraform in actions

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -38,6 +38,12 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+            terraform_version: "^1.3.7"
+            terraform_wrapper: false
+
       - name: Terraform init
         working-directory: terraform/azure/aks
         run: terraform init


### PR DESCRIPTION
Terraform is no longer included in the latest ubuntu runners: https://github.com/actions/runner-images/issues/10796

Fixes this ci issue: https://github.com/fermyon/spinkube-performance/actions/runs/13020760703/job/36320671713